### PR TITLE
Fix par Christophe

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -13,7 +13,6 @@ export default function LabelBottomNavigation () {
   const pathMap = [
     '/',
     '/liste_freelance/',
-
     '/mentions_legales'
   ];
 

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -15,7 +15,7 @@ function About () {
         <h1>A propos</h1>
 
         <div className='paragraphe'>
-          <h3>Dénommination :</h3>
+          <h3>Dénomination :</h3>
           <p>Freelances Lyonnais</p>
         </div>
 

--- a/src/pages/Detail.scss
+++ b/src/pages/Detail.scss
@@ -165,6 +165,7 @@
 
 .mainSkills {
   height: 345px;
+  overflow: scroll;
 }
 
 .mainSkills ul {
@@ -174,7 +175,7 @@
 #detailskillstjm {
   margin-block-end: 0;
   position: absolute;
-  bottom: 0;
+  /* bottom: 0px; */
   left: 0;
   width: 100%;
   height: 50px;

--- a/src/pages/Tags.scss
+++ b/src/pages/Tags.scss
@@ -52,35 +52,29 @@ body {
 
 @media screen and (min-width: 1024px) {
 .listingTags {
-
-    column-count:4;
-    text-align: left;
-    margin: 50px 50px 50px 150px;
-    column-gap: 40px;
-    font-size: larger;
+  column-count:4;
+  text-align: left;
+  margin: 50px 50px 50px 150px;
+  column-gap: 40px;
+  font-size: larger;
 }
 
 .tags h1 {
-
-    letter-spacing: 2px;
-    position: relative;
-    text-align: center;
-    color: var(--blue);
-
+  letter-spacing: 2px;
+  position: relative;
+  text-align: center;
+  color: var(--blue);
   }
 
   .tags h2 {
-
-      text-align: left;
-      margin-left: 150px;
-      margin-top: 80px;
+    text-align: left;
+    margin-left: 150px;
+    margin-top: 80px;
   }
 
-li {
-    
-list-style: none;
-padding: 10px;
+  .tags li {
+    list-style: none;
+    padding: 10px;
+  }
+}
 
-}
-}
-   

--- a/src/pages/generic page/Home.js
+++ b/src/pages/generic page/Home.js
@@ -1,7 +1,10 @@
 import React from 'react';
-import './Home.scss';
 import logo from './logo.png';
 import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import './Home.scss';
 
 const title = 'Accueil Freelances Lyonnais';
 
@@ -18,7 +21,10 @@ function Home () {
 
         <div className='paragraphe'>
           <h3>Qui se cache derrière Les Freelances Lyonnais ? </h3>
-          <p>Si vous êtes arrivé.e.s sur cette page, c’est que vous en connaissez au moins un.e :) Vous avez apprécié la qualité de son travail, sa proximité géographique, et sa disponibilité. Imaginez maintenant qu’on vous dise qu’on connaît 1800 autres professionnel.le.s comme ça ?</p>
+          <p style={{ marginTop: '16px', marginBottom: '0' }}>Si vous êtes arrivé.e.s sur cette page, c’est que vous en connaissez au moins un.e :) Vous avez apprécié la qualité de son travail, sa proximité géographique, et sa disponibilité. Imaginez maintenant qu’on vous dise qu’on connaît 1800 autres professionnel.le.s comme ça ?</p>
+          <Button variant="contained" color='primary' style={{ backgroundColor: '#1E2CFB' }}>
+            <Link style={{ color: 'white' }} to='/liste_freelance/'>Les Freelances Lyonnais</Link>
+          </Button>
         </div>
 
         <div className='paragraphe'>

--- a/src/pages/generic page/Home.js
+++ b/src/pages/generic page/Home.js
@@ -28,7 +28,7 @@ function Home () {
 
         <div className='paragraphe'>
           <h3>Un arsenal de compétences dans lequel piocher </h3>
-          <p>L’annuaire des Freelances, c’est un peu comme faire son marché ou visiter son magasin de quartier : vous appuyez le commerce local et vous avez l’avantage d’une offre sur mesure, dans votre langue, voire votre quartier ! Ce Freelance bénéficie de l’appui de son réseau pour aller chercher un compétence additionnelle dont votre projet aura besoin, soumettre à la sagesse de la foule connaisseuse les questions pointues ou encore vous référer un autre prestataire de confiance.</p>
+          <p>L’annuaire des Freelances, c’est un peu comme faire son marché ou visiter son magasin de quartier : vous appuyez le commerce local et vous avez l’avantage d’une offre sur mesure, dans votre langue, voire votre quartier ! Ce Freelance bénéficie de l’appui de son réseau pour aller chercher une compétence additionnelle dont votre projet aura besoin, soumettre à la sagesse de la foule connaisseuse les questions pointues ou encore vous référer un autre prestataire de confiance.</p>
         </div>
       </main>
     </div>

--- a/src/pages/generic page/Home.js
+++ b/src/pages/generic page/Home.js
@@ -22,7 +22,7 @@ function Home () {
         <div className='paragraphe'>
           <h3>Qui se cache derrière Les Freelances Lyonnais ? </h3>
           <p style={{ marginTop: '16px', marginBottom: '0' }}>Si vous êtes arrivé.e.s sur cette page, c’est que vous en connaissez au moins un.e :) Vous avez apprécié la qualité de son travail, sa proximité géographique, et sa disponibilité. Imaginez maintenant qu’on vous dise qu’on connaît 1800 autres professionnel.le.s comme ça ?</p>
-          <Button variant="contained" color='primary' style={{ backgroundColor: '#1E2CFB' }}>
+          <Button variant='contained' color='primary' style={{ backgroundColor: '#1E2CFB' }}>
             <Link style={{ color: 'white' }} to='/liste_freelance/'>Les Freelances Lyonnais</Link>
           </Button>
         </div>
@@ -34,7 +34,10 @@ function Home () {
 
         <div className='paragraphe'>
           <h3>Un arsenal de compétences dans lequel piocher </h3>
-          <p>L’annuaire des Freelances, c’est un peu comme faire son marché ou visiter son magasin de quartier : vous appuyez le commerce local et vous avez l’avantage d’une offre sur mesure, dans votre langue, voire votre quartier ! Ce Freelance bénéficie de l’appui de son réseau pour aller chercher une compétence additionnelle dont votre projet aura besoin, soumettre à la sagesse de la foule connaisseuse les questions pointues ou encore vous référer un autre prestataire de confiance.</p>
+          <p style={{ marginTop: '16px', marginBottom: '0' }}>L’annuaire des Freelances, c’est un peu comme faire son marché ou visiter son magasin de quartier : vous appuyez le commerce local et vous avez l’avantage d’une offre sur mesure, dans votre langue, voire votre quartier ! Ce Freelance bénéficie de l’appui de son réseau pour aller chercher une compétence additionnelle dont votre projet aura besoin, soumettre à la sagesse de la foule connaisseuse les questions pointues ou encore vous référer un autre prestataire de confiance.</p>
+          <Button variant='contained' color='primary' style={{ backgroundColor: '#1E2CFB' }}>
+            <Link style={{ color: 'white' }} to='/inscription/'>Je créé ma fiche freelance gratuitement</Link>
+          </Button>
         </div>
       </main>
     </div>

--- a/src/pages/generic page/LegalDisclaimer.js
+++ b/src/pages/generic page/LegalDisclaimer.js
@@ -14,7 +14,7 @@ function LegalDisclaimer () {
         <h1>Mentions légales</h1>
 
         <div className='paragraphe'>
-          <h3>Dénommination :</h3>
+          <h3>Dénomination :</h3>
           <p>Freelances Lyonnais</p>
         </div>
 


### PR DESCRIPTION
Ce qui a été fait : 
- sur page d'accueil : ajout d'un bouton d'accès direct à la liste des freelances sous le premier paragraphe et ajout d'un second bouton, à la suite du dernier paragraphe vers la page d'inscription.
- Corrections d'erreurs de typo signalées dans les retours d'expériences de certains membres testeurs.
- Ajout d'un ascenseur pour la liste des tags dans la section des compétences sur la page détail de chaque FL.
- Déplacement vers le bas de la barre de taux journalier moyen car elle gênait l'affichage des tags.